### PR TITLE
Added spinner support on forms with data-remote

### DIFF
--- a/src/rails/ujs.js
+++ b/src/rails/ujs.js
@@ -66,7 +66,9 @@
       var form = event.target;
       if (form.has('data-remote') && !user_cancels(event, form)) {
         event.stop();
-        form.send(add_xhr_events(form));
+        form.send(add_xhr_events(form, {
+          spinner:  form.get('data-spinner') || form.first('.spinner')
+        }));
       }
     }
   });


### PR DESCRIPTION
The Rails3 driver already supports remote link spinners with data-spinner. This commit does the same with remote forms, and if data-spinner is not found for the form, it looks for a spinner the same way form.remotize() did (form.first('.spinner')).
