### PR TITLE
Fixed `slideIn` and `slideDown` method names.

### DIFF
--- a/src/jquerysh/element.js
+++ b/src/jquerysh/element.js
@@ -82,11 +82,11 @@ RightJS.Element.include({
     return this.fade('out');
   },
 
-  slideIn: function() {
+  slideDown: function() {
     return this.slide('in');
   },
 
-  slideOut: function() {
+  slideUp: function() {
     return this.slide('out');
   }
 


### PR DESCRIPTION
`slideUp` and `slideDown` are the actual jQuery method names. See: http://api.jquery.com/category/effects/sliding/
